### PR TITLE
Add an organization README file

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,54 @@
+[![Strimzi](https://raw.githubusercontent.com/strimzi/.github/main/logo/strimzi.png)](https://strimzi.io/)
+
+# Run Apache Kafka® on Kubernetes
+
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Twitter Follow](https://img.shields.io/twitter/follow/strimziio?style=social)](https://twitter.com/strimziio)
+
+Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on Kubernetes in various deployment configurations.
+See our [website](https://strimzi.io) for more details about the project.
+
+## Getting in touch
+
+If you want to get in touch with us, you can use:
+
+* [`#strimzi` channel on CNCF Slack](https://slack.cncf.io/)
+* [Strimzi Users mailing list](https://lists.cncf.io/g/cncf-strimzi-users/topics)
+* [GitHub Discussions](https://github.com/orgs/strimzi/discussions)
+
+## Strimzi Community Meetings
+
+You can join our regular community meetings:
+
+* Thursday 8:00 AM UTC (every 4 weeks starting from 4th June 2020) - [convert to your timezone](https://www.thetimezoneconverter.com/?t=8%3A00&tz=UTC)
+* Thursday 4:00 PM UTC (every 4 weeks starting from 18th June 2020) - [convert to your timezone](https://www.thetimezoneconverter.com/?t=16%3A00&tz=UTC)
+
+Resources:
+* [Meeting minutes, agenda, and Zoom link](https://docs.google.com/document/d/1V1lMeMwn6d2x1LKxyydhjo2c_IFANveelLD880A6bYc/edit#heading=h.vgkvn1hr5uor)
+* [Recordings](https://youtube.com/playlist?list=PLpI4X8PMthYfONZopcRd4X_stq1C14Rtn)
+* [Calendar](https://calendar.google.com/calendar/embed?src=c_m9pusj5ce1b4hr8c92hsq50i00%40group.calendar.google.com) ([Subscribe to the calendar](https://calendar.google.com/calendar/u/0?cid=Y19tOXB1c2o1Y2UxYjRocjhjOTJoc3E1MGkwMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t))
+
+## Contributing
+
+You can contribute by:
+- Raising any issues you find using Strimzi
+- Fixing issues by opening Pull Requests
+- Improving documentation
+- Talking about Strimzi
+
+Find out more about the different ways how to contribute on the [Join Us](https://strimzi.io/join-us/) page.
+If you want to get in touch with us first before contributing, you can use:
+
+* [`#strimzi` channel on CNCF Slack](https://slack.cncf.io/)
+* [Strimzi Dev mailing list](https://lists.cncf.io/g/cncf-strimzi-dev/topics)
+* [GitHub Discussions](https://github.com/orgs/strimzi/discussions)
+
+## License
+
+Strimzi is licensed under the [Apache License](https://github.com/strimzi/.github/blob/main/LICENSE), Version 2.0
+
+---
+
+Strimzi is a [Cloud Native Computing Foundation](https://www.cncf.io/) project.
+
+[![CNCF ><](https://raw.githubusercontent.com/strimzi/.github/main/logo/cncf-color.png)](https://www.cncf.io/)


### PR DESCRIPTION
This PR adds an organization README file which should show up on the GitHub organization page. It contains some basic information and links that apply to all of our repos.